### PR TITLE
feat: make designs mostly mobile responsive

### DIFF
--- a/src/components/box/box.css.js
+++ b/src/components/box/box.css.js
@@ -1,30 +1,45 @@
 import styled from 'styled-components';
+import MEDIA from 'helpers/mediaTemplates';
 
 export const Container = styled.div`
-  padding: 12rem 0rem 0rem 12rem;
-  height: 37rem;
-  background-color: #98C2E7;
+  min-height: 37rem;
+  background-color: #98c2e7;
+  margin-bottom: 2rem;
+
+  ${MEDIA.DESKTOP`
+    padding: 12rem 0rem 0rem 12rem;
+  `}
+
+  ${MEDIA.IPAD`
+    padding: 2rem;
+  `}
 `;
 
 export const Submit = styled.div`
-  background-color: #EA364C;
-  height: 69px;	
-  width: 261px;	
+  background-color: #ea364c;
+  height: 69px;
+  width: 261px;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
 
   &:hover {
     cursor: pointer;
   }
+
+  ${MEDIA.IPAD`
+    margin: 0 auto;
+  `}
 `;
 
 export const SubmitText = styled.div`
-  height: 26px;
-  width: 210px;
-  color: #FEFFFE;
+  min-height: 26px;
+  min-width: 210px;
+  color: #fefffe;
   font-family: Futura;
   font-size: 20px;
   font-weight: bold;
   letter-spacing: 2px;
-  line-height: 27px;	
+  line-height: 27px;
   padding-top: 2rem;
   text-align: center;
   margin: 0 auto;
@@ -35,19 +50,32 @@ export const WhatWould = styled.div`
   font-family: Futura;
   font-size: 24px;
   font-weight: bold;
-  height: 62px;
   line-height: 32px;
-  padding-bottom: 1rem;
-  text-align: center;
-  width: 687px;
+  max-width: 687px;
+  padding-bottom: 2rem;
+
+  ${MEDIA.DESKTOP`
+    padding-top: 2rem;
+  `}
+
+  ${MEDIA.IPAD`
+    padding-top: 0rem;
+    text-align: center;
+  `}
 `;
 export const YourVoice = styled.div`
-  color: #FEFFFF;
+  color: #feffff;
   font-family: Futura;
   font-size: 36px;
   font-weight: bold;
-  height: 92px;
   line-height: 47px;
-  padding-bottom: 4rem;
-  width: 622px;
+  max-width: 622px;
+
+  ${MEDIA.DESKTOP`
+    padding-bottom: 2rem;
+  `}
+
+  ${MEDIA.IPAD`
+    text-align: center;
+  `}
 `;

--- a/src/components/gallery-header/gallery-header.css.js
+++ b/src/components/gallery-header/gallery-header.css.js
@@ -4,15 +4,25 @@ import MEDIA from 'helpers/mediaTemplates';
 export const Container = styled.div`
   padding: 0 4rem 0 12rem;
   margin: 4rem 0 3rem;
+
+  ${MEDIA.DESKTOP`
+    padding: 0 4rem 0 12rem;
+  `}
+
+  ${MEDIA.IPAD`
+    padding: 0 4rem 0 4rem;
+  `}
 `;
 
 export const BigText = styled.div`
-  height: 46px;
-  width: 418px;
   color: #000000;
   font-family: Futura;
   font-size: 36px;
   font-weight: bold;
   line-height: 47px;
-  text-align: center;
+
+  ${MEDIA.IPAD`
+    font-size: 24px;
+    text-align: center;
+  `}
 `;

--- a/src/components/gallery-header/gallery-header.js
+++ b/src/components/gallery-header/gallery-header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BigText, Container } from './gallery-header.css';
 
-const Gallery = ({ items }) => (
+const Gallery = () => (
   <Container>
     <BigText>Featured Submissions</BigText>
   </Container>

--- a/src/components/gallery/gallery.css.js
+++ b/src/components/gallery/gallery.css.js
@@ -8,27 +8,28 @@ export const Container = styled.div`
   padding: 2rem 10rem 0rem 12rem;
 
   @media (max-width: 1667px) {
-    grid-template-columns: repeat(3, 1fr);  
+    grid-template-columns: repeat(3, 1fr);
   }
 
   @media (max-width: 1281px) {
-    grid-template-columns: repeat(2, 1fr);  
+    grid-template-columns: repeat(2, 1fr);
   }
 
   @media (max-width: 994px) {
-    grid-template-columns: repeat(1, 1fr);  
+    grid-template-columns: repeat(1, 1fr);
   }
-  
+
   ${MEDIA.IPAD_PRO`
     grid-gap: 6rem 12rem;
   `};
 
   ${MEDIA.IPAD`
     grid-gap: 4rem 4rem;
-    padding: 0rem 2rem 0rem 8rem;
+    justify-items: center;
+    padding: 0rem;
   `};
 
   ${MEDIA.PHONE`
     grid-template-columns: repeat(1, 1fr);
-  `}  
+  `}
 `;


### PR DESCRIPTION
Only item not fixed yet was the header so it still breaks and overlaps. I think that should collapse to a hamburger menu button.

Desktop:
<img width="1440" alt="Screen Shot 2019-03-29 at 12 57 47 AM" src="https://user-images.githubusercontent.com/1296389/55217892-d83c2580-51bd-11e9-94d7-6da927464efb.png">

Mobile:
<img width="401" alt="Screen Shot 2019-03-29 at 12 57 34 AM" src="https://user-images.githubusercontent.com/1296389/55217893-d8d4bc00-51bd-11e9-8ffe-cd8597534c62.png">
